### PR TITLE
Feat: Multiple client with the same account

### DIFF
--- a/internal/adaptor/websocket/backgroud_process.go
+++ b/internal/adaptor/websocket/backgroud_process.go
@@ -26,7 +26,7 @@ func (s *messageServer) broadcastMessages() {
 	for id, c := range s.clients {
 		select {
 		case <-c.terminate:
-			s.removeClientByUserID(id)
+			s.removeClientByID(id)
 
 		case msg, ok := <-c.message:
 			c.mu.Lock()

--- a/internal/adaptor/websocket/backgroud_process.go
+++ b/internal/adaptor/websocket/backgroud_process.go
@@ -26,7 +26,7 @@ func (s *messageServer) broadcastMessages() {
 	for id, c := range s.clients {
 		select {
 		case <-c.terminate:
-			s.removeClient(id)
+			s.removeClientByUserID(id)
 
 		case msg, ok := <-c.message:
 			c.mu.Lock()
@@ -39,15 +39,30 @@ func (s *messageServer) broadcastMessages() {
 
 			if err := c.connection.WriteMessage(websocket.TextMessage, msg); err != nil {
 				log.Println("write error:", err)
-				c.terminate <- true
-				_ = c.connection.WriteMessage(websocket.CloseMessage, []byte{})
-				c.connection.Close()
-				c.isClosed = true
+				c.close()
 			}
 
 			c.mu.Unlock()
 
 		default:
 		}
+	}
+}
+
+func (s *messageServer) sendPings() {
+	for id, c := range s.clients {
+		c.mu.Lock()
+
+		if c.isClosed {
+			c.mu.Unlock()
+			continue
+		}
+
+		if err := c.connection.WriteMessage(websocket.PingMessage, []byte("ping")); err != nil {
+			log.Printf("Ping failed to user %s: %v", id, err)
+			c.close()
+		}
+
+		c.mu.Unlock()
 	}
 }

--- a/internal/adaptor/websocket/client.go
+++ b/internal/adaptor/websocket/client.go
@@ -1,14 +1,13 @@
 package websocket
 
 import (
-	"log"
 	"sync"
 
 	"github.com/gofiber/contrib/websocket"
 	"github.com/yokeTH/gofiber-template/internal/domain"
 )
 
-type Client struct {
+type client struct {
 	id         string
 	isClosed   bool
 	terminate  chan bool
@@ -20,15 +19,14 @@ type Client struct {
 	profile    domain.Profile
 }
 
-func (c *Client) sendError(message string) {
-	if err := c.connection.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
-		c.isClosed = true
-		log.Println("write error:", err)
-		if err := c.connection.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
-			log.Print("write close err:", err)
-		}
-		c.connection.Close()
-	}
+func (c *client) sendError(message string) {
+	_ = c.connection.WriteMessage(websocket.TextMessage, []byte(message))
+	c.connection.Close()
+}
+
+func (c *client) close() {
+	_ = c.connection.WriteMessage(websocket.CloseMessage, []byte{})
+	c.terminate <- true
 	c.isClosed = true
 	c.connection.Close()
 }

--- a/internal/adaptor/websocket/client.go
+++ b/internal/adaptor/websocket/client.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Client struct {
+	id         string
 	isClosed   bool
 	terminate  chan bool
 	wg         *sync.WaitGroup

--- a/internal/adaptor/websocket/server.go
+++ b/internal/adaptor/websocket/server.go
@@ -163,6 +163,7 @@ func (m *messageServer) getClientByUserID(userID string) []*client {
 	return clients
 }
 
+//nolint:unused
 func (s *messageServer) removeClientByUserID(id string) {
 	s.wrmu.Lock()
 	defer s.wrmu.Unlock()
@@ -173,6 +174,27 @@ func (s *messageServer) removeClientByUserID(id string) {
 			delete(s.clients, client.id)
 			_ = s.userUC.SetUserOffline(id)
 		}
+	}
+}
+
+func (s *messageServer) removeClientByID(id string) {
+	s.wrmu.Lock()
+	defer s.wrmu.Unlock()
+	client, ok := s.clients[id]
+	if !ok {
+		return
+	}
+	client.wg.Done()
+	delete(s.clients, id)
+	userID := client.userID
+	cnt := 0
+	for _, client := range s.clients {
+		if client.userID == userID {
+			cnt++
+		}
+	}
+	if cnt == 0 {
+		_ = s.userUC.SetUserOffline(userID)
 	}
 }
 


### PR DESCRIPTION
## Change
handle multiple client with same account by using as request-id as a key and update `getClient` to return a slices of client to send a message.